### PR TITLE
migrate to zoho

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     install_requires = ['Django==1.10.2',
                         'sshpubkeys==2.2.0',
                         'psycopg2==2.7.6.1',
-                        'requests==2.12.5',
                         'gunicorn==19.6.0',
                         'Mastodon.py==1.1.1',
                         'tweepy==3.5.0'],

--- a/ttadmin/common/mailing.py
+++ b/ttadmin/common/mailing.py
@@ -1,35 +1,26 @@
 import logging
-
-import requests
+from smtplib import SMTP_SSL, SMTPException
+from email.message import EmailMessage
 
 from django.conf import settings
 
 logger = logging.getLogger()
 
-ADMIN_NAME='vilmibm'
-EXTERNAL_FROM='root@tilde.town'
-REPLY_TO='tildetown@protonmail.ch'
 
 def send_email(to, body, subject='a message from tilde.town'):
-    """Sends an email using mailgun. Logs on failure."""
-    response =  requests.post(
-        settings.MAILGUN_URL,
-        auth=('api', settings.MAILGUN_KEY),
-        data={
-            'from': EXTERNAL_FROM,
-            'h:Reply-To': REPLY_TO,
-            'to': to,
-            'subject': subject,
-            'text': body
-        }
-    )
+    """Sends an email using external SMTP. Logs on failure."""
+    em = EmailMessage()
+    em['Subject'] = subject
+    em['From'] = 'root@tilde.town'
+    em['To'] = to
+    em.set_content(body)
+    try:
+        with SMTP_SSL(port=settings.SMTP_PORT, host=settings.SMTP_HOST) as smtp:
+            smtp.login('root@tilde.town', settings.SMTP_PASSWORD)
+            smtp.send_message(em)
+            smtp.quit()
+    except SMTPException as e:
+        logger.error(f'failed to send email "{subject}" to {to}: {e}')
+        return False
 
-    success = response.status_code == 200
-
-    if not success:
-        logger.error('{}: failed to send email "{}" to {}'.format(
-            response.status_code,
-            subject,
-            to))
-
-    return success
+    return True

--- a/ttadmin/settings.py
+++ b/ttadmin/settings.py
@@ -6,7 +6,7 @@ To run this For Real, you'll want to:
  * set a different SECRET_KEY
  * change the password for the database or delete the password and use ident
  * change DEBUG to False
- * set mailgun api info
+ * set smtp password
 """
 import os
 
@@ -101,8 +101,9 @@ STATIC_URL = '/static/'
 # Not used during local development, but used in staging+live environments
 STATIC_ROOT = 'static'
 
-MAILGUN_URL = "OVERWRITE THIS"
-MAILGUN_KEY = "OVERWRITE THIS"
+SMTP_PORT=465
+SMTP_HOST="smtp.zoho.com"
+SMTP_PASSWORD="OVERWRITE THIS"
 
 # Mastodon credentials
 MASTO_CLIENT_ID = "OVERWRITE THIS"

--- a/ttadmin/users/models.py
+++ b/ttadmin/users/models.py
@@ -47,7 +47,7 @@ class Townie(User):
     reasons = TextField(blank=True, null=False, default='')
     plans = TextField(blank=True, null=False, default='')
     socials = TextField(blank=True, null=False, default='')
-    referral = CharField(max_length=100, null=True)
+    referral = CharField(max_length=100, null=True, blank=True)
     displayname = CharField(max_length=100, blank=False, null=False)
 
     @property


### PR DESCRIPTION
since mailgun isn't designed for our needs we're switching to zoho for email.

this means admins can share a common mailbox with a nice GUI and we can use it to send emails over SMTP. Emails sent this way will be copied to the `sent` folder in the GUI for easy review of what emails the admin system is sending.

This makes it much easier to send email and opens us up to using more email features, like automatically sending email from the helpdesk admin area and sending emails warning about account renames.

This PR replaces our REST integration with mailgun with an SMTP integration with zoho

after merging:
- [ ] update live settings